### PR TITLE
Aligned Converter constructor with changes in AsciidoctorJ

### DIFF
--- a/core/src/main/groovy/org/asciidoctor/converters/AbstractMarkdownConverter.groovy
+++ b/core/src/main/groovy/org/asciidoctor/converters/AbstractMarkdownConverter.groovy
@@ -12,7 +12,7 @@ abstract class AbstractMarkdownConverter extends AbstractConverter {
 
     static final String LINESEP = "\n"
 
-    AbstractMarkdownConverter(final String backend,Map<Object, Object> opts) {
+    AbstractMarkdownConverter(final String backend,Map<String, Object> opts) {
         super(backend, opts)
     }
 

--- a/core/src/main/groovy/org/asciidoctor/converters/AbstractMultiOutputMarkdownConverter.groovy
+++ b/core/src/main/groovy/org/asciidoctor/converters/AbstractMultiOutputMarkdownConverter.groovy
@@ -19,7 +19,7 @@ import java.util.regex.Pattern
 @Slf4j
 abstract class AbstractMultiOutputMarkdownConverter extends AbstractMarkdownConverter {
 
-    AbstractMultiOutputMarkdownConverter(final String backend,Map<Object, Object> opts) {
+    AbstractMultiOutputMarkdownConverter(final String backend,Map<String, Object> opts) {
         super(backend, opts)
     }
 

--- a/core/src/main/groovy/org/asciidoctor/markdown/MarkdownConverter.groovy
+++ b/core/src/main/groovy/org/asciidoctor/markdown/MarkdownConverter.groovy
@@ -6,7 +6,7 @@ import org.asciidoctor.converters.AbstractMarkdownConverter
  * @author Schalk W. Cronjé
  */
 class MarkdownConverter extends AbstractMarkdownConverter {
-    MarkdownConverter(final String backend,Map<Object, Object> opts) {
+    MarkdownConverter(final String backend,Map<String, Object> opts) {
         super(backend, opts)
     }
 }


### PR DESCRIPTION
The constructor called by AsciidoctorJ used to pass a Map<Object, Object>.
This changed to passing a Map<String, Object>.
